### PR TITLE
Update jQuery

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/FortAwesome/Font-Awesome v0.0.0-20220322152429-28e297f07af2 // indirect
-	github.com/jquery/jquery v0.0.0-20190501210434-75f7e963708b // indirect
+	github.com/jquery/jquery v0.0.0-20221003210637-aa231cd21421 // indirect
 	github.com/js-cookie/js-cookie v2.2.1+incompatible // indirect
 	github.com/twbs/bootstrap v4.5.2+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
 github.com/FortAwesome/Font-Awesome v0.0.0-20220322152429-28e297f07af2/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
-github.com/jquery/jquery v0.0.0-20190501210434-75f7e963708b/go.mod h1:awH0v5ImrD4lpSNYgzEFDJGCfWp3Y+4uYc2qFZDen9w=
+github.com/jquery/jquery v0.0.0-20221003210637-aa231cd21421/go.mod h1:awH0v5ImrD4lpSNYgzEFDJGCfWp3Y+4uYc2qFZDen9w=
 github.com/js-cookie/js-cookie v2.2.1+incompatible/go.mod h1:vKvo6V0OyHfzKLjBW9nzJCpzN2tIDjUoYspuk9aDv/k=
 github.com/twbs/bootstrap v4.5.2+incompatible h1:QR6UOtm1+LCDK53CzEp8U0NPIYeRUktVgNhq0gaAGP0=
 github.com/twbs/bootstrap v4.5.2+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=


### PR DESCRIPTION
Hi, I noticed that we were getting some vulnerability warnings for using an outdated version of jQuery. I've updated our modules to use the latest version here.
 
<img width="727" alt="Screen Shot 2022-10-04 at 9 19 32 AM" src="https://user-images.githubusercontent.com/13243031/193859179-451dfc4a-4e7b-437a-bee7-8f3a60f58c86.png">

I've also tagged this v1.0.7. Let me know if you need anything else from me. Thanks!